### PR TITLE
Font shorthand property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0 (2015-08-02)
+
+- Added: Font shorthand property
+
 ## 0.1.2 (2015-06-23)
 
 - Fixed: Optimization

--- a/index.js
+++ b/index.js
@@ -10,5 +10,14 @@ module.exports = postcss.plugin('postcss-font-weights', function (opts) {
 				decl.value = fontweights[decl.value];
 			}
 		});
+		css.eachDecl('font', function (decl) {
+            var key, re;
+			for (key in fontweights) {
+                if (key !== 'normal') { // normal is a keyword for several different font properties
+                    re = new RegExp('\\b' + key + '\\b', 'g');
+				    decl.value = decl.value.replace(re, fontweights[key]);
+                }
+			}
+		});
 	};
 });

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ module.exports = postcss.plugin('postcss-font-weights', function (opts) {
 			}
 		});
 		css.eachDecl('font', function (decl) {
-            var key, re;
+			var key, re;
 			for (key in fontweights) {
-                if (key !== 'normal') { // normal is a keyword for several different font properties
-                    re = new RegExp('\\b' + key + '\\b', 'g');
-				    decl.value = decl.value.replace(re, fontweights[key]);
-                }
+				if (key !== 'normal') { // normal is a keyword for several different font properties
+					re = new RegExp('\\b' + key + '\\b', 'g');
+					decl.value = decl.value.replace(re, fontweights[key]);
+				}
 			}
 		});
 	};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
 	"name": "postcss-font-weights",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"description": "PostCSS plugin to transform font weight names into numeric font weight values",
 	"keywords": ["postcss", "css", "postcss-plugin", "fonts", "weights", "names"],
 	"author": "Jonathan Neal <jonathantneal@hotmail.com>",
 	"contributors": [
-		"Bogdan Chadkin <trysound@yandex.ru>"
+		"Bogdan Chadkin <trysound@yandex.ru>",
+        "David Walsh <dlwalsh@gmail.com>"
 	],
 	"license": "CC0-1.0",
 	"repository": {

--- a/test/test-shorthand.js
+++ b/test/test-shorthand.js
@@ -1,0 +1,124 @@
+var postcss = require('postcss');
+var expect  = require('chai').expect;
+
+var plugin = require('../');
+
+var test = function (input, output, opts, done) {
+	postcss([ plugin(opts) ]).process(input).then(function (result) {
+		expect(result.css).to.eql(output);
+		expect(result.warnings()).to.be.empty;
+		done();
+	}).catch(function (error) {
+		done(error);
+	});
+};
+
+describe('postcss-font-weights', function () {
+	it('transforms font: thin', function (done) {
+		test('a{font: thin 16px Arial, sans-serif}', 'a{font: 100 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: extralight', function (done) {
+		test('a{font: extralight 16px Arial, sans-serif}', 'a{font: 200 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: ultralight', function (done) {
+		test('a{font: ultralight 16px Arial, sans-serif}', 'a{font: 200 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: light', function (done) {
+		test('a{font: light 16px Arial, sans-serif}', 'a{font: 300 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: book', function (done) {
+		test('a{font: book 16px Arial, sans-serif}', 'a{font: 400 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: regular', function (done) {
+		test('a{font: regular 16px Arial, sans-serif}', 'a{font: 400 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: roman', function (done) {
+		test('a{font: roman 16px Arial, sans-serif}', 'a{font: 400 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: medium', function (done) {
+		test('a{font: medium 16px Arial, sans-serif}', 'a{font: 500 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: demibold', function (done) {
+		test('a{font: demibold 16px Arial, sans-serif}', 'a{font: 600 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: semibold', function (done) {
+		test('a{font: semibold 16px Arial, sans-serif}', 'a{font: 600 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: bold', function (done) {
+		test('a{font: bold 16px Arial, sans-serif}', 'a{font: 700 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: extrabold', function (done) {
+		test('a{font: extrabold 16px Arial, sans-serif}', 'a{font: 800 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: ultrabold', function (done) {
+		test('a{font: ultrabold 16px Arial, sans-serif}', 'a{font: 800 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: black', function (done) {
+		test('a{font: black 16px Arial, sans-serif}', 'a{font: 900 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('transforms font: heavy', function (done) {
+		test('a{font: heavy 16px Arial, sans-serif}', 'a{font: 900 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: normal', function (done) {
+		test('a{font: normal 16px Arial, sans-serif}', 'a{font: normal 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 100', function (done) {
+		test('a{font: 100 16px Arial, sans-serif}', 'a{font: 100 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 200', function (done) {
+		test('a{font: 200 16px Arial, sans-serif}', 'a{font: 200 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 300', function (done) {
+		test('a{font: 300 16px Arial, sans-serif}', 'a{font: 300 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 400', function (done) {
+		test('a{font: 400 16px Arial, sans-serif}', 'a{font: 400 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 500', function (done) {
+		test('a{font: 500 16px Arial, sans-serif}', 'a{font: 500 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 600', function (done) {
+		test('a{font: 600 16px Arial, sans-serif}', 'a{font: 600 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 700', function (done) {
+		test('a{font: 700 16px Arial, sans-serif}', 'a{font: 700 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 800', function (done) {
+		test('a{font: 800 16px Arial, sans-serif}', 'a{font: 800 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: 900', function (done) {
+		test('a{font: 900 16px Arial, sans-serif}', 'a{font: 900 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: lighter', function (done) {
+		test('a{font: lighter 16px Arial, sans-serif}', 'a{font: lighter 16px Arial, sans-serif}', {}, done);
+	});
+
+	it('preserves font: bolder', function (done) {
+		test('a{font: bolder 16px Arial, sans-serif}', 'a{font: bolder 16px Arial, sans-serif}', {}, done);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ var test = function (input, output, opts, done) {
 };
 
 describe('postcss-font-weights', function () {
-	it('transforms font-weight thin', function (done) {
+	it('transforms font-weight: thin', function (done) {
 		test('a{font-weight: thin}', 'a{font-weight: 100}', {}, done);
 	});
 
@@ -112,5 +112,13 @@ describe('postcss-font-weights', function () {
 
 	it('preserves font-weight: 900', function (done) {
 		test('a{font-weight: 900}', 'a{font-weight: 900}', {}, done);
+	});
+
+	it('preserves font-weight: lighter', function (done) {
+		test('a{font-weight: lighter}', 'a{font-weight: lighter}', {}, done);
+	});
+
+	it('preserves font-weight: bolder', function (done) {
+		test('a{font-weight: bolder}', 'a{font-weight: bolder}', {}, done);
 	});
 });


### PR DESCRIPTION
I've added a second transform for the `font` shorthand property.

I've made no attempt to parse the `font` property. It simply does a find and replace for each key/pair value. For this reason I've left out `normal`, since (a) its already a valid CSS value and (b) `normal` can also be a value for other font properties (`font-style`, `font-variant` etc.).

The version number has been bumped up to 0.2.0.
